### PR TITLE
Fixed stretching of infobutton

### DIFF
--- a/src/HeaderBar.vala
+++ b/src/HeaderBar.vala
@@ -42,6 +42,7 @@ namespace Resizer {
             var info_menu = new Gtk.MenuButton ();
             info_menu.tooltip_text = _("Info");
             info_menu.image = new Gtk.Image.from_icon_name ("dialog-information", Gtk.IconSize.SMALL_TOOLBAR);
+            info_menu.valign = Gtk.Align.CENTER;
             info_menu.popover = infoPopover;
 
             pack_end (info_menu);


### PR DESCRIPTION
The info button was stretching to fill the headerbar resulting in stretched accent highlights.  I personally think a centered button leads to a more aesthetically pleasing look for the accent highlights. Before and after shown in image.

![resizer_fix](https://user-images.githubusercontent.com/29067795/133441630-9c677a76-e91f-417c-8deb-9a5b237ded67.png)
